### PR TITLE
Fixed formatted string issue when generating

### DIFF
--- a/src/openapi_parser/openapi_parser.py
+++ b/src/openapi_parser/openapi_parser.py
@@ -161,7 +161,7 @@ class OpenAPIParser:
                 ]
             )
         if "not" in schema:
-            return f"Not[{self._resolve_type(schema["not"])}]"
+            return f"Not[{self._resolve_type(schema['not'])}]"
         return schema.get("type", "any")
 
     def _extract_refs(self, schema: Dict[str, Any]) -> List[str]:


### PR DESCRIPTION
The "not" was being recognized as an un-closed formatted string. Using 'not' fixed the issue.